### PR TITLE
Add bucket ID to Runscope test resource

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -43,7 +43,6 @@ The following arguments are supported:
 * `access_token` - (Required) The Runscope access token.
   This can also be specified with the `RUNSCOPE_ACCESS_TOKEN` shell
   environment variable.
-* `bucket_id` - (Required) The ID of the bucket to create the test.
 * `api_url` - (Optional) If set, specifies the Runscope api url, this
    defaults to `"https://api.runscope.com`. This can also be specified
    with the `RUNSCOPE_API_URL` shell environment variable.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -32,7 +32,7 @@ resource "runscope_bucket" "main" {
 resource "runscope_test" "api" {
   name         = "api-test"
   description  = "checks the api is up and running"
-  bucket_id    = "${runscope_bucket.main}"
+  bucket_id    = "${runscope_bucket.main.id}"
 }
 ```
 
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `access_token` - (Required) The Runscope access token.
   This can also be specified with the `RUNSCOPE_ACCESS_TOKEN` shell
   environment variable.
+* `bucket_id` - (Required) The ID of the bucket to create the test.
 * `api_url` - (Optional) If set, specifies the Runscope api url, this
    defaults to `"https://api.runscope.com`. This can also be specified
    with the `RUNSCOPE_API_URL` shell environment variable.


### PR DESCRIPTION
Adds missing bucket ID argument to Runscope test resource usage and argument reference