### PR TITLE
Added support for test step notes.

### DIFF
--- a/runscope/resource_runscope_step.go
+++ b/runscope/resource_runscope_step.go
@@ -135,6 +135,10 @@ func resourceRunscopeStep() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"note": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -189,6 +193,7 @@ func resourceStepRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("headers", readHeaders(step.Headers))
 	d.Set("scripts", step.Scripts)
 	d.Set("before_scripts", step.BeforeScripts)
+	d.Set("note", step.Note)
 	if step.Auth != nil && len(step.Auth) > 0 {
 		d.Set("auth", []interface{}{
 			map[string]interface{}{
@@ -213,7 +218,8 @@ func resourceStepUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.HasChange("variables") ||
 		d.HasChange("assertions") ||
 		d.HasChange("headers") ||
-		d.HasChange("body") {
+		d.HasChange("body") ||
+		d.HasChange("note") {
 		client := meta.(*runscope.Client)
 		_, err = client.UpdateTestStep(stepFromResource, bucketID, testID)
 
@@ -319,6 +325,10 @@ func createStepFromResourceData(d *schema.ResourceData) (*runscope.TestStep, str
 
 	if attr, ok := d.GetOk("before_scripts"); ok {
 		step.BeforeScripts = expandStringList(attr.([]interface{}))
+	}
+
+	if attr, ok := d.GetOk("note"); ok {
+		step.Note = attr.(string)
 	}
 
 	return step, bucketID, testID, nil

--- a/runscope/resource_runscope_step_test.go
+++ b/runscope/resource_runscope_step_test.go
@@ -201,6 +201,7 @@ resource "runscope_step" "main_page" {
   bucket_id      = "${runscope_bucket.bucket.id}"
   test_id        = "${runscope_test.test.id}"
   step_type      = "request"
+  note           = "Testing step, single step test"
   url            = "http://example.com"
   method         = "GET"
   variables      = [
@@ -274,13 +275,15 @@ resource "runscope_step" "step_a" {
   bucket_id      = "${runscope_bucket.bucket.id}"
   test_id        = "${runscope_test.test_a.id}"
   step_type      = "request"
+  note           = "Multiple step test, test a"
   url            = "http://step_a.com"
   method         = "GET"
 }
 resource "runscope_step" "step_b" {
-  bucket_id      = "${runscope_bucket.bucket.id}"
+  bucket_id      = "${runscope_bucket.bucket.id}"c
   test_id        = "${runscope_test.test_a.id}"
   step_type      = "request"
+  note           = "Multiple step test, test b"
   url            = "http://step_b.com"
   method         = "GET"
 }

--- a/runscope/resource_runscope_step_test.go
+++ b/runscope/resource_runscope_step_test.go
@@ -156,6 +156,10 @@ func testAccCheckStepMainPageExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Expected %s, actual %s", "log(\"before script\");", foundRecord.BeforeScripts[0])
 		}
 
+		if foundRecord.Note != "Testing step, single step test" {
+			return fmt.Errorf("Expected note %s, actual note %s", "Testing step, single step test", foundRecord.Note)
+		}
+
 		return nil
 	}
 }

--- a/website/docs/r/step.html.markdown
+++ b/website/docs/r/step.html.markdown
@@ -20,6 +20,7 @@ resource "runscope_step" "main_page" {
   test_id        = "${runscope_test.test.id}"
   step_type      = "request"
   url            = "http://example.com"
+  note           = "A comment for the test step"
   method         = "GET"
   variables      = [
   	{
@@ -96,6 +97,7 @@ The following arguments are supported:
 
 * `bucket_id` - (Required) The id of the bucket to associate this step with.
 * `test_id` - (Required) The id of the test to associate this step with.
+* `note` = (Optional) A comment attached to the test step.
 * `step_type` - (Required) The type of step.
  * [request](#request-steps)
  * pause


### PR DESCRIPTION
This PR adds the ability to have notes attached to test steps from terraform definition, which is useful when for example looking at terraform-created steps from web ui or other location.